### PR TITLE
ignore strings and template literals for line length

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     "mocha/no-mocha-arrows": "error",
     "max-len": [ "error", {
       "code": 80,
-      "ignorePattern": "^.*require\\s*\\("
+      "ignoreStrings": true,
+      "ignoreTemplateLiterals": true
     } ],
     "array-bracket-spacing": [ "error", "always" ],
     "object-curly-spacing": [ "error", "always"],

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ exports.notOk = ['1', '2']
 Lines may not be longer than 80 characters.
 
 ```javascript
-// requires are ignored, so this is ok:
+// strings are ignored, so this is ok:
 const myModule = require('../test/../test/../test/../test/../test/../test/../test/../test/../test')
 
 // this is not ok:
-myModule.doSomeCalculationThatTakesALongTimeToExplain('it', 'also', 'takes', 'arguments')
+myModule.doSomeCalculationThatTakesALongTimeToExplain(91872094182750910, 19248712349, 90)
 ```
 
 ### `require-path-exists`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/wunderflats/eslint-config-wunderflats",
   "dependencies": {
-    "eslint": "^3.4.0",
+    "eslint": "3.7.1",
     "eslint-config-standard": "^6.0.0",
     "eslint-plugin-mocha": "^4.5.1",
     "eslint-plugin-promise": "^2.0.1",

--- a/test/fixtures/max-len.js
+++ b/test/fixtures/max-len.js
@@ -1,7 +1,4 @@
 'use strict'
 
-// requires are ignored, so this is ok:
-const myModule = require('../test/../test/../test/../test/../test/../test/../test/../test/../index')
-
 // this is not ok:
-myModule.doSomeCalculationThatTakesALongTimeToExplain('it', 'also', 'takes', 'arguments')
+global.doSomeCalculationThatTakesALongTimeToExplain(91872094182750910, 19248712349, 90)

--- a/test/fixtures/max-len.ok.js
+++ b/test/fixtures/max-len.ok.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const myModule = require('../test/../test/../test/../test/../test/../test/../test/../test/../index')
+
+myModule.doSomthing(`
+  this is a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long template string ${myModule.doSomthing()}
+`)

--- a/test/index.js
+++ b/test/index.js
@@ -4,14 +4,31 @@ const assert = require('assert')
 const path = require('path')
 const exec = require('child_process').exec
 
-exec('node_modules/.bin/eslint test/fixtures', {
+exec('node_modules/.bin/eslint test/fixtures/max-len.js', {
   cwd: path.resolve(__dirname, '..'),
   env: process.env
 }, function (err, stdout) {
   assert.ok(err)
 
   assert(/exceeds the maximum line length of 80/.test(stdout),
+  'does not enforce maximum line length of 80')
+})
+
+exec('node_modules/.bin/eslint test/fixtures/max-len.ok.js', {
+  cwd: path.resolve(__dirname, '..'),
+  env: process.env
+}, function (err, stdout) {
+  assert.equal(err, null, 'does not exit cleanly')
+
+  assert.equal(/exceeds the maximum line length of 80/.test(stdout), false,
     'does not enforce maximum line length of 80')
+})
+
+exec('node_modules/.bin/eslint test/fixtures', {
+  cwd: path.resolve(__dirname, '..'),
+  env: process.env
+}, function (err, stdout) {
+  assert.ok(err)
 
   assert(/Unexpected exclusive mocha test/.test(stdout),
     'does not enforce exclusive mocha tests')


### PR DESCRIPTION
- use exact dependencies
- :arrow_up: eslint@3.7.1
